### PR TITLE
Rails 5 compatibility

### DIFF
--- a/administrate-field-password.gemspec
+++ b/administrate-field-password.gemspec
@@ -17,5 +17,5 @@ Gem::Specification.new do |gem|
   gem.test_files = `git ls-files -- {test,spec,features}/*`.split("\n")
 
   gem.add_dependency 'administrate', '>= 0.2.0.rc1', '< 0.3.0'
-  gem.add_dependency 'rails', '~> 4.2'
+  gem.add_dependency 'rails', '>= 4.2'
 end

--- a/administrate-field-password.gemspec
+++ b/administrate-field-password.gemspec
@@ -1,10 +1,8 @@
 $:.push File.expand_path('../lib', __FILE__)
 
-require 'administrate/field/password'
-
 Gem::Specification.new do |gem|
   gem.name = 'administrate-field-password'
-  gem.version = Administrate::Field::Password::VERSION
+  gem.version = "0.0.2"
   gem.authors = ['Adrian Rangel']
   gem.email = ['adrian@disruptiveangels.com']
   gem.homepage = 'https://github.com/disruptiveangels/administrate-field-password'

--- a/lib/administrate/field/password.rb
+++ b/lib/administrate/field/password.rb
@@ -4,7 +4,6 @@ require 'rails'
 module Administrate
   module Field
     class Password < Administrate::Field::Base
-      VERSION = '0.0.2'
       class Engine < ::Rails::Engine
       end
 


### PR DESCRIPTION
Since Rails 5 compatibility is coming in the upstream administrate, here's a quick PR to make this field still work in that version.

I've also moved the `VERSION` out of lib. The reason for this was a circular dependency issue when installing to a clean environment - loading the file containing `VERSION` required administrate to be installed, but it is not installed at the time Bundler needs to read the `VERSION` to calculate dependencies.
